### PR TITLE
Add configurable logging across core modules

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,5 +42,6 @@
     "radius": 1,
     "FPS": 30,
     "V_current": 0,
-    "beta_current": 30.0
+    "beta_current": 30.0,
+    "log_level": "INFO"
 }

--- a/config_paper.json
+++ b/config_paper.json
@@ -36,5 +36,6 @@
     "radius": 1,
     "FPS": 30,
     "V_current": 0,
-    "beta_current": 30.0
+    "beta_current": 30.0,
+    "log_level": "INFO"
 }

--- a/controllers/BaseController.py
+++ b/controllers/BaseController.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC
 from collections.abc import Sequence
 from typing import Dict, List, Optional
@@ -6,6 +7,9 @@ import numpy as np
 
 from spaces import BaseSpace
 from tqdm import tqdm
+
+
+logger = logging.getLogger(__name__)
 
 class BaseController(ABC):
     name = 'base_controller'
@@ -46,9 +50,11 @@ class BaseController(ABC):
 
     def set_data_storage(self, data_storage) -> None:
         self.data_storage = data_storage
+        logger.debug("Data storage configured for controller '%s' -> %s", self.name, data_storage)
 
     def get_plot_path(self, plot_name: str, extension: str) -> str:
         if self.data_storage is None:
+            logger.error("Attempted to access plot path '%s.%s' before configuring data storage", plot_name, extension)
             raise RuntimeError("Data storage must be configured before generating plot paths")
         return self.data_storage.get_path(plot_name, extension)
 
@@ -83,6 +89,7 @@ class BaseController(ABC):
         snapshot: Dict[str, object] = {}
         for name in requested:
             if not hasattr(self, name):
+                logger.error("Snapshot requested unknown attribute '%s' on controller '%s'", name, self.name)
                 raise AttributeError(f"Controller '{self.name}' has no attribute '{name}' for plotting")
             snapshot[name] = getattr(self, name)
         return snapshot
@@ -97,6 +104,13 @@ class BaseController(ABC):
         m_nu = []
         m_u_actual = []
         m_eta = []
+
+        logger.info(
+            "Controller '%s' starting simultaneous simulation with %d vehicle(s) and %d steps",
+            self.name,
+            self.number_of_vehicles,
+            self.N,
+        )
 
         for vehicle in self.vehicles:
             m_eta.append(np.array([vehicle.starting_point[1], vehicle.starting_point[0], 0, 0, 0, 0], float))
@@ -125,4 +139,5 @@ class BaseController(ABC):
                 m_u_actual[internal_number] = u_actual
 
         self.sim_data = sim_data
+        logger.info("Controller '%s' completed simulation", self.name)
         return sim_data

--- a/controllers/manager.py
+++ b/controllers/manager.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
+import logging
+
 import numpy as np
 
 from tools.dataStorage import ControllerAssignment, DataStorage
 
 from .BaseController import BaseController
 from . import create_instance, get_controller_type
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -36,6 +41,11 @@ class ControllerManager:
         self._vehicle_serials: Dict[BaseController, List[int]] = {}
         self._data_storage: Optional[DataStorage] = None
 
+        logger.debug(
+            "ControllerManager initialized with %d controller/vehicle group(s)",
+            len(self._controller_vehicle_groups),
+        )
+
     @property
     def controllers(self) -> List[BaseController]:
         return list(self._controllers)
@@ -54,19 +64,31 @@ class ControllerManager:
         self._vehicle_serials.clear()
 
         self._data_storage = data_storage.create_child_storage("controllers")
+        logger.debug("Created controller root data storage at %s", self._data_storage.timestamped_folder)
 
         for assignment_index, (assignment, vehicles) in enumerate(self._controller_vehicle_groups, start=1):
             controller_mode = get_controller_type(assignment.controller_type)
             if controller_mode == "swarm":
+                logger.info(
+                    "Initializing swarm controller '%s' with %d vehicle(s)",
+                    assignment.controller_type,
+                    len(vehicles),
+                )
                 controller = self._instantiate_controller(assignment.controller_type, vehicles, space)
                 self._register_controller(controller, assignment_index, vehicles)
             elif controller_mode == "individual":
+                logger.info(
+                    "Initializing individual controller '%s' for %d vehicle(s)",
+                    assignment.controller_type,
+                    len(vehicles),
+                )
                 for vehicle in vehicles:
                     controller = self._instantiate_controller(assignment.controller_type, [vehicle], space)
                     self._register_controller(controller, assignment_index, [vehicle])
             else:
                 raise ValueError(f"Unsupported controller type: {controller_mode}")
 
+        logger.info("Initialized %d controller instance(s)", len(self._controllers))
         return self.controller_runs
 
     def set_run_result(self, index: int, result=None) -> None:
@@ -74,6 +96,7 @@ class ControllerManager:
         if result is None:
             result = getattr(controller, "sim_data", None)
         self.controller_runs[index] = (controller, result)
+        logger.debug("Stored run result for controller #%d (%s)", index + 1, controller.name)
 
     def aggregate_metric(self, metric_name: str) -> AggregatedMetric:
         attribute = metric_name
@@ -134,8 +157,14 @@ class ControllerManager:
         self.controller_runs.append((controller, None))
         self._vehicle_serials[controller] = [vehicle.serial_number for vehicle in vehicles]
 
-        print(controller)
-        print(f"Controller storage: {controller_storage.timestamped_folder}")
+        logger.info(
+            "Registered controller '%s' (%s) for assignment %d with %d vehicle(s); storage=%s",
+            controller.name,
+            controller.abbreviation,
+            assignment_index,
+            len(vehicles),
+            controller_storage.timestamped_folder,
+        )
 
     @staticmethod
     def _build_storage_name(controller: BaseController,

--- a/controllers/plot_jobs.py
+++ b/controllers/plot_jobs.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass
 from typing import Sequence, Optional, Dict, Any
+import logging
 import shutil
 import numpy as np
+
+
+logger = logging.getLogger(__name__)
 
 def _cm2inch(v: float) -> float: return v / 2.54
 
@@ -19,20 +23,23 @@ class TrackJob:
     label: str = ""
 
 def run_track_render(job: TrackJob) -> None:
+    if not logging.getLogger().handlers:
+        logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
     import matplotlib; matplotlib.use("Agg")             # set non-interactive backend INSIDE subprocess
     import matplotlib.pyplot as plt
     import matplotlib.animation as animation
     from matplotlib import rc, rcParams, rcParamsDefault
     if job.label:
-        print(f"[TrackRender] Starting '{job.label}'", flush=True)
+        logger.info("[TrackRender] Starting '%s'", job.label)
     rcParams.update(rcParamsDefault)
     use_latex = bool(job.use_latex)
     if use_latex and shutil.which('latex') is None:
         use_latex = False
         if job.label:
-            print(f"[TrackRender] '{job.label}' falling back to non-LaTeX labels: 'latex' executable not found", flush=True)
+            logger.warning("[TrackRender] '%s' falling back to non-LaTeX labels: 'latex' executable not found", job.label)
         else:
-            print("[TrackRender] Falling back to non-LaTeX labels: 'latex' executable not found", flush=True)
+            logger.warning("[TrackRender] Falling back to non-LaTeX labels: 'latex' executable not found")
     plt.rc('text', usetex=use_latex); rc('font', size=30)
 
     # required keys: grid_x, grid_y, grid_z, target_isoline, isolines, fps, grid_size
@@ -68,9 +75,9 @@ def run_track_render(job: TrackJob) -> None:
         if not has_ffmpeg:
             reason = "'ffmpeg' executable not found"
             if job.label:
-                print(f"[TrackRender] '{job.label}' skipping animation: {reason}", flush=True)
+                logger.warning("[TrackRender] '%s' skipping animation: %s", job.label, reason)
             else:
-                print(f"[TrackRender] Skipping animation: {reason}", flush=True)
+                logger.warning("[TrackRender] Skipping animation: %s", reason)
         else:
             def anim_fn(k: int):
                 artists = []
@@ -89,11 +96,11 @@ def run_track_render(job: TrackJob) -> None:
                 writer = None
             if writer is None:
                 if job.label:
-                    print(f"[TrackRender] '{job.label}' falling back to PillowWriter: FFMpegWriter unavailable", flush=True)
+                    logger.warning("[TrackRender] '%s' falling back to PillowWriter: FFMpegWriter unavailable", job.label)
                 else:
-                    print("[TrackRender] Falling back to PillowWriter: FFMpegWriter unavailable", flush=True)
+                    logger.warning("[TrackRender] Falling back to PillowWriter: FFMpegWriter unavailable")
                 writer = animation.PillowWriter(fps=fps)
             ani.save(job.out_gif, writer=writer)
     plt.close(fig)
     if job.label:
-        print(f"[TrackRender] Finished '{job.label}'", flush=True)
+        logger.info("[TrackRender] Finished '%s'", job.label)

--- a/lib/gnc.py
+++ b/lib/gnc.py
@@ -10,8 +10,12 @@ URL: www.fossen.biz/wiley
 Author:     Thor I. Fossen
 """
 
-import numpy as np
+import logging
 import math
+import numpy as np
+
+
+logger = logging.getLogger(__name__)
 
 
 #------------------------------------------------------------------------------
@@ -117,7 +121,7 @@ def Tzyx(phi, theta):
             [0, sphi / cth, cphi / cth]])
 
     except ZeroDivisionError:
-        print("Tzyx is singular for theta = +-90 degrees.")
+        logger.error("Tzyx is singular for theta = +-90 degrees.")
 
     return T
 

--- a/main.py
+++ b/main.py
@@ -21,6 +21,36 @@ from lib import *
 from tools import *
 
 WORK_THRESHOLD = 3000
+DEFAULT_CONFIG_FILENAME = "config.json"
+
+
+def _resolve_config_path(cli_path: str) -> str:
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    candidate = cli_path or DEFAULT_CONFIG_FILENAME
+    if not os.path.isabs(candidate):
+        candidate = os.path.join(base_dir, candidate)
+    return candidate
+
+
+def _configure_log_level(level_name: str, logger: logging.Logger) -> int:
+    if isinstance(level_name, str):
+        level = getattr(logging, level_name.upper(), None)
+        if not isinstance(level, int):
+            logger.warning("Unknown log level '%s', defaulting to INFO", level_name)
+            level = logging.INFO
+    elif isinstance(level_name, int):
+        level = level_name
+    else:
+        logger.warning("Unsupported log level type %s, defaulting to INFO", type(level_name).__name__)
+        level = logging.INFO
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    for handler in root_logger.handlers:
+        handler.setLevel(level)
+    logger.setLevel(level)
+    logger.info("Log level configured: %s", logging.getLevelName(level))
+    return level
 
 
 def _controller_label(idx, controller):
@@ -72,7 +102,16 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
     logger = logging.getLogger("otter.main")
 
-    arguments = read_and_assign_arguments(args.config_filename)
+    config_filename = _resolve_config_path(args.config_filename)
+    logger.info("Using configuration file: %s", config_filename)
+    if not os.path.exists(config_filename):
+        logger.error("Configuration file not found: %s", config_filename)
+        raise FileNotFoundError(config_filename)
+
+    arguments = read_and_assign_arguments(config_filename)
+    configured_level = getattr(arguments, "log_level", "INFO")
+    effective_level = _configure_log_level(configured_level, logger)
+    arguments.log_level = logging.getLevelName(effective_level)
     controller_vehicle_pairs = ControllerVehiclePairs(arguments.controller_vehicle_pairs)
 
     ###############################################################################
@@ -97,14 +136,14 @@ if __name__ == '__main__':
 
     for _, vehicles in controller_vehicle_groups:
         for vehicle in vehicles:
-            print(vehicle)
+            logger.info("Configured vehicle: %s", vehicle)
 
     controller_manager = ControllerManager(controller_vehicle_groups, arguments)
 
     if arguments.clean_cache:
         clean_data()
     if arguments.big_picture:
-        print('BE CAREFUL THE BIG PICTURE MODE REQUIRES MORE MEMORY')
+        logger.warning('BE CAREFUL THE BIG PICTURE MODE REQUIRES MORE MEMORY')
     space = sp.create_instance(arguments.peak_type,
                                x_range=(-arguments.axis_abs_max, arguments.axis_abs_max),
                                y_range=(-arguments.axis_abs_max, arguments.axis_abs_max),
@@ -113,7 +152,7 @@ if __name__ == '__main__':
                                space_filename=arguments.peaks_filename,
                                target_isoline=arguments.target_isoline)
     space.set_contour_points(tol=1)
-    print(space)
+    logger.info("Space configuration:\n%s", space)
 
     for i in range(arguments.cycles):
         logger.info("Starting cycle %d/%d", i + 1, arguments.cycles)
@@ -257,10 +296,15 @@ if __name__ == '__main__':
         space.store_in_config()
         for controller_index, (controller, _) in enumerate(controller_runs):
             for vehicle_index, error_sum in enumerate(controller.sum_error_values):
-                print(f'controller {controller_index + 1} vehicle {vehicle_index}: e_norm = {error_sum / controller.sim_time}')
-            print(controller.e_max)
+                logger.info(
+                    "Controller %d vehicle %d: e_norm = %.6f",
+                    controller_index + 1,
+                    vehicle_index,
+                    error_sum / controller.sim_time,
+                )
+            logger.info("Controller %d maximum error threshold: %.6f", controller_index + 1, controller.e_max)
 
         logger.info("Cycle %d/%d completed", i + 1, arguments.cycles)
 
     logger.info("All cycles completed")
-    print('Done!')
+    logger.info('Done!')

--- a/tools/dataStorage.py
+++ b/tools/dataStorage.py
@@ -1,9 +1,13 @@
-import os
 import datetime
-import shutil
 import json
+import logging
+import os
+import shutil
 from dataclasses import dataclass
 from typing import Iterable, Iterator, List, Optional, Sequence, Tuple
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -70,6 +74,8 @@ class ControllerVehiclePairs(Iterable[ControllerAssignment]):
         self._assignments: List[ControllerAssignment] = []
         self._sanitized: List[dict] = []
 
+        logger.debug("Parsing %d controller assignment(s)", len(pairs))
+
         for idx, pair in enumerate(pairs):
             if not isinstance(pair, dict):
                 raise TypeError(f"controller_vehicle_pairs[{idx}] must be a JSON object")
@@ -112,6 +118,13 @@ class ControllerVehiclePairs(Iterable[ControllerAssignment]):
                 sanitized_entry["start_points"] = [list(point) for point in start_points]
 
             self._sanitized.append(sanitized_entry)
+
+        total_vehicles = sum(assignment.total_vehicles() for assignment in self._assignments)
+        logger.info(
+            "Configured %d controller assignment(s) with %d total vehicle(s)",
+            len(self._assignments),
+            total_vehicles,
+        )
 
     def __iter__(self) -> Iterator[ControllerAssignment]:
         return iter(self._assignments)
@@ -183,6 +196,8 @@ def create_timestamped_folder(*args, base_path="./data", timestamped_suffix="") 
     # Create the new folder
     os.makedirs(folder_path, exist_ok=True)
 
+    logger.debug("Ensured data directory exists: %s", folder_path)
+
     return folder_path
 
 
@@ -200,9 +215,9 @@ def clean_data() -> None:
     if os.path.exists(data_folder_path) and os.path.isdir(data_folder_path):
         # Delete the 'data' folder and its contents
         shutil.rmtree(data_folder_path)
-        print(f"Deleted 'data' folder at: {data_folder_path}")
+        logger.info("Deleted 'data' folder at %s", data_folder_path)
     else:
-        print(f"'data' folder does not exist at: {data_folder_path}")
+        logger.info("'data' folder does not exist at %s", data_folder_path)
 
 
 class DataStorage:
@@ -212,21 +227,30 @@ class DataStorage:
                                                             f"s{series + 1}",
                                                             timestamped_suffix=self.timestamped_suffix,
                                                             base_path=f"./{cache_dir}")
+        logger.debug(
+            "Initialized DataStorage for type '%s' (series %s) at %s",
+            typename,
+            series + 1,
+            self.timestamped_folder,
+        )
 
     def __str__(self):
         return f'Result folder: {self.timestamped_folder}'
 
     def get_path(self, name, expansion) -> str:
-        return os.path.join(self.timestamped_folder,
+        path = os.path.join(self.timestamped_folder,
                             create_timestamped_filename_ext(name,
                                                             self.timestamped_suffix,
                                                             expansion))
+        logger.debug("Resolved path for %s.%s -> %s", name, expansion, path)
+        return path
 
     def create_child_storage(self, name: str) -> "DataStorage":
         child = DataStorage.__new__(DataStorage)
         child.timestamped_suffix = self.timestamped_suffix
         child.timestamped_folder = os.path.join(self.timestamped_folder, name)
         os.makedirs(child.timestamped_folder, exist_ok=True)
+        logger.debug("Created child storage '%s' at %s", name, child.timestamped_folder)
         return child
 
 
@@ -257,10 +281,13 @@ class Arguments:
 
 
 def read_and_assign_arguments(input_filename) -> Arguments:
+    logger.info("Loading configuration from %s", input_filename)
     with open(input_filename, 'r') as file:
         data = json.load(file)
 
-    return Arguments(**data)
+    arguments = Arguments(**data)
+    logger.debug("Loaded configuration keys: %s", ", ".join(sorted(data.keys())))
+    return arguments
 
 
 def overwrite_file(old_name, new_name) -> None:


### PR DESCRIPTION
## Summary
- add a `log_level` option to the simulation configs and honor it during startup
- replace ad-hoc prints with structured logging across controllers, plotting jobs, and utilities
- expand controller and data storage lifecycle instrumentation to aid debugging and observability

## Testing
- python -m compileall main.py controllers tools spaces lib

------
https://chatgpt.com/codex/tasks/task_e_6901f6ce6c248332a07b01da2df00654